### PR TITLE
Cancel subscriptions bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bjornagh/use-fetch",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "An easy-to-use React hook for doing fetch requests",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/useFetch.js
+++ b/src/useFetch.js
@@ -167,7 +167,10 @@ function useFetch({
           return response;
         })
         .catch(error => {
-          setError(error);
+          if (!abortControllerRef.current.signal.aborted) {
+            setError(error);
+          }
+
           onError(error);
 
           return error;


### PR DESCRIPTION
Hi @bghveding 

There's a small bug in the lib causing a warning/error, when the component hosting the `useFetch` hook has been unmounted while a request is still in progress.
Unmounting the component (rightly) causes an abort of the request. 
An abort is seen as an error by fetch and here's where the issue lies:
- in the `catch` block, the lib tries to `setError(error)`.
If the component has already been unmounted, this will cause the following warning/error:
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

This PR applies a fix to the issue, by not trying to update the state of an unmounted component if the error is caused by an aborted signal.